### PR TITLE
Fix: double end call

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-pulsar/src/opentelemetry/instrumentation/pulsar/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pulsar/src/opentelemetry/instrumentation/pulsar/__init__.py
@@ -142,7 +142,6 @@ def wrap_message_listener(topic, tracer, message_listener):
             message.partition_key(),
         )
         _enrich_span_with_message(span, message)
-        message._set_current_span(span)
         with trace.use_span(span, True):
             return message_listener(consumer, message, *args, **kwargs)
 

--- a/instrumentation/opentelemetry-instrumentation-pulsar/src/opentelemetry/instrumentation/pulsar/version.py
+++ b/instrumentation/opentelemetry-instrumentation-pulsar/src/opentelemetry/instrumentation/pulsar/version.py
@@ -1,5 +1,5 @@
 # Copyright The OpenTelemetry Authors
-#
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.38b0.dev"
+__version__ = "0.38b1.dev"


### PR DESCRIPTION
# Description

This fixes a double call to `span.end()` caused by the fact that we store in the message a span that will be already ended when the context ends, but is also ended on any call to a `*acknowledge` function.

The change only removes setting this span in the message, essentially skipping it on any call to a `*acknowledge` function.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
